### PR TITLE
don't panic on failure to parse and test case

### DIFF
--- a/sexprs.go
+++ b/sexprs.go
@@ -45,6 +45,7 @@ import (
 	"io"
 	"io/ioutil"
 	"strconv"
+	"errors"
 )
 
 var (
@@ -430,7 +431,8 @@ func readSimpleString(r *bufio.Reader, first byte) (s []byte, err error) {
 			}
 		}
 	}
-	panic("can't get here")
+	err = errors.New("can't readSimpleString")
+	return
 }
 
 func readLengthDelimited(r *bufio.Reader, first byte) (s []byte, err error) {

--- a/sexprs_test.go
+++ b/sexprs_test.go
@@ -44,6 +44,17 @@ func TestParseEmptyList(t *testing.T) {
 	t.Log(string(l.Pack()))
 }
 
+
+func TestError(t *testing.T) {
+	confirmError := func(a string) {
+		_, _, err := Parse([]byte(a))
+		if err == nil {
+			t.Fatalf("Parsing %v should have produced an error", a)
+		}
+	}
+	confirmError("((a)")
+}
+
 func TestParse(t *testing.T) {
 	s, _, err := Parse([]byte("([text]test)"))
 	if err != nil {


### PR DESCRIPTION
This way I don't get runtime errors when parsing bad data.  Maybe the other panic statements deserve to remain as they are?  Would you still prefer panic to error in this case?  
